### PR TITLE
gherkin-jvm-deps v1.1.x multi-release jar for jpms

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.cucumber</groupId>
     <artifactId>gherkin-jvm-deps</artifactId>
-    <version>1.0.5-SNAPSHOT</version>
+    <version>1.1.6-SNAPSHOT</version>
     <name>Gherkin Repackaged Dependencies</name>
     <url>https://github.com/cucumber/gherkin-jvm-deps</url>
     <parent>
@@ -45,14 +45,42 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <id>java11</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <release>11</release>
+                            <jdkToolchain>
+                                <version>11</version>
+                            </jdkToolchain>
+                            <compileSourceRoots>
+                                <compileSourceRoot>${project.basedir}/src/main/java11</compileSourceRoot>
+                            </compileSourceRoots>
+                            <multiReleaseOutput>true</multiReleaseOutput>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.1.0</version>
                 <configuration>
                     <archive>
                         <manifestEntries>
                             <Automatic-Module-Name>${project.Automatic-Module-Name}</Automatic-Module-Name>
+                            <Multi-Release>true</Multi-Release>
                         </manifestEntries>
                     </archive>
+                    <excludes>
+                        <exclude>**/ModuleInfoHack.class</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
             <plugin>
@@ -71,6 +99,26 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-toolchains-plugin</artifactId>
+                <version>1.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>toolchain</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <toolchains>
+                        <jdk>
+                            <version>${base.java.version}</version>
+                            <vendor>${toolchain.vendor}</vendor>
+                        </jdk>
+                    </toolchains>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -161,5 +209,7 @@
         <project.build.outputEncoding>${project.custom.encoding}</project.build.outputEncoding>
         <project.reporting.outputEncoding>${project.custom.encoding}</project.reporting.outputEncoding>
         <project.Automatic-Module-Name>io.cucumber.gherkin.jvm.deps</project.Automatic-Module-Name>
+        <toolchain.vendor>openjdk</toolchain.vendor>
+        <base.java.version>1.8</base.java.version>
     </properties>
 </project>

--- a/src/main/java11/gherkin/deps/com/google/gson/ModuleInfoHack.java
+++ b/src/main/java11/gherkin/deps/com/google/gson/ModuleInfoHack.java
@@ -1,0 +1,4 @@
+package gherkin.deps.com.google.gson;
+
+public class ModuleInfoHack {
+}

--- a/src/main/java11/gherkin/deps/com/google/gson/annotations/ModuleInfoHack.java
+++ b/src/main/java11/gherkin/deps/com/google/gson/annotations/ModuleInfoHack.java
@@ -1,0 +1,4 @@
+package gherkin.deps.com.google.gson.annotations;
+
+public class ModuleInfoHack {
+}

--- a/src/main/java11/gherkin/deps/com/google/gson/reflect/ModuleInfoHack.java
+++ b/src/main/java11/gherkin/deps/com/google/gson/reflect/ModuleInfoHack.java
@@ -1,0 +1,4 @@
+package gherkin.deps.com.google.gson.reflect;
+
+public class ModuleInfoHack {
+}

--- a/src/main/java11/gherkin/deps/com/google/gson/stream/ModuleInfoHack.java
+++ b/src/main/java11/gherkin/deps/com/google/gson/stream/ModuleInfoHack.java
@@ -1,0 +1,4 @@
+package gherkin.deps.com.google.gson.stream;
+
+public class ModuleInfoHack {
+}

--- a/src/main/java11/gherkin/deps/net/iharder/ModuleInfoHack.java
+++ b/src/main/java11/gherkin/deps/net/iharder/ModuleInfoHack.java
@@ -1,0 +1,4 @@
+package gherkin.deps.net.iharder;
+
+public class ModuleInfoHack {
+}

--- a/src/main/java11/module-info.java
+++ b/src/main/java11/module-info.java
@@ -1,0 +1,9 @@
+module io.cucumber.gherkin.jvm.deps {
+    exports gherkin.deps.com.google.gson;
+    exports gherkin.deps.com.google.gson.annotations;
+    exports gherkin.deps.com.google.gson.reflect;
+    exports gherkin.deps.com.google.gson.stream;
+    exports gherkin.deps.net.iharder;
+    opens gherkin.deps.com.google.gson.internal to io.cucumber.gherkin;
+    requires java.sql;
+}


### PR DESCRIPTION
Add Module-Info so gherkin v5.2.x can use modules correctly on java 9+.

Can this be release as 1.1.x so once i've finished fixing downstream I can patch if needed.